### PR TITLE
chore: add launch eap server command

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -43,7 +43,14 @@ commands:
       commandLine: mvn clean install
       group:
         kind: build
-  - id: run
+  - id: launch-eap-server
+    exec:
+      component: tools
+      workingDir: ${PROJECTS_ROOT}
+      commandLine: $JBOSS_HOME/bin/openshift-launch.sh
+      group:
+        kind: run
+  - id: deploy
     exec:
       component: tools
       workingDir: ${PROJECTS_ROOT}/microprofile-quickstart/microprofile-fault-tolerance


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>
Add a command to Launch EAP server before deploying the application

Related Issue: https://issues.redhat.com/browse/CRW-2966