### PR TITLE
chore: add m2 voulume into eap component

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -13,6 +13,9 @@ components:
     container:
       image: registry.redhat.io/jboss-eap-7/eap-xp3-openjdk11-openshift-rhel8:3.0
       memoryLimit: 1Gi
+      volumeMounts:
+        - name: m2
+          path: /home/jboss/.m2
       env:
         - name: JAVA_OPTS_APPEND
           value: '-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dsun.util.logging.disableCallerCheck=true'


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

Add .m2 volume into eap-xp component 
![screenshot-devspaces-openshift-workspaces apps ocp410-oshmara crw-qe com-2022 06 13-15_28_45](https://user-images.githubusercontent.com/1271546/173353933-7c83bd91-6d6a-451c-8396-9d6ccfba153d.png)

