### PR TITLE
chore: override default Java compiler and maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
 
         <jboss.developer.drupal.url>http://rhdp-drupal.stage.redhat.com/</jboss.developer.drupal.url>
         <linkXRef>false</linkXRef>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <version.compiler.plugin>3.10.1</version.compiler.plugin>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Related issue: https://issues.redhat.com/browse/CRW-3013
![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2022 06 21-14_42_24](https://user-images.githubusercontent.com/1271546/174791360-8b7f1cbf-f18f-4321-b8ec-92ad89fe127b.png)

